### PR TITLE
adds space in task-controller, so build doesn't fail

### DIFF
--- a/src/tasks/task-controller.ts
+++ b/src/tasks/task-controller.ts
@@ -22,7 +22,7 @@ export default class TaskController {
         try {
             let task: ITask = await this.database.taskModel.create(newTask);
             return reply(task).code(201);
-        }catch (error) {
+        } catch (error) {
             return reply(Boom.badImplementation(error));
         }
     }


### PR DESCRIPTION
Very tiny fix! There was a `}` touching the `catch`, so the build was failing. Adds a space. 